### PR TITLE
SumRep __call__ bugfix

### DIFF
--- a/emlp/reps/product_sum_reps.py
+++ b/emlp/reps/product_sum_reps.py
@@ -66,7 +66,7 @@ class SumRep(Rep):
         return SumRepFromCollection(self.reps),self.perm
 
     def __call__(self,G):
-        return SumRepFromCollection({rep.T:c for rep,c in self.reps.items()},perm=self.perm)
+        return SumRepFromCollection({rep(G):c for rep,c in self.reps.items()},perm=self.perm)
 
     @property
     def concrete(self):


### PR DESCRIPTION
Wrong behavior for SumRep __call__ function due to a typo. Not showing up in tests or model examples because the reps are typically initialized before adding together to form a SumRep, however, if you add first then initialize with some non orthogonal representations then previously the rep would behave incorrectly (and silently).